### PR TITLE
fix-e2e-seed-type-error

### DIFF
--- a/scripts/seed-test-data.ts
+++ b/scripts/seed-test-data.ts
@@ -62,7 +62,7 @@ const TEST_ORG = {
   slug: 'nutritest',
 };
 
-async function createTestUser(userData: typeof TEST_USERS.admin) {
+async function createTestUser(userData: typeof TEST_USERS[keyof typeof TEST_USERS]) {
   // Check if user exists
   const { data: existingUsers } = await supabase.auth.admin.listUsers();
   const existingUser = existingUsers?.users?.find(u => u.email === userData.email);


### PR DESCRIPTION
Fix TypeScript type error in `createTestUser()` function that prevents E2E tests from running. The function parameter type is overly restrictive, accepting only `profile_role: 'nutri'` when it should accept all user types (nutri, patient, receptionist).