### PR TITLE
feat: conditionally show challenges tab for patients

### DIFF
--- a/src/app/patient/layout.tsx
+++ b/src/app/patient/layout.tsx
@@ -13,6 +13,9 @@ export default async function PatientRootLayout({
 
   // Check if user is authenticated and is a patient
   let isAuthenticated = false;
+  let hasChallenges = false;
+  let patientId: string | null = null;
+
   if (user) {
     const { data: patient } = await supabase
       .from("patients")
@@ -22,6 +25,17 @@ export default async function PatientRootLayout({
       .single();
 
     isAuthenticated = !!patient;
+    patientId = patient?.id || null;
+
+    // Check if patient has any challenge participations
+    if (patientId) {
+      const { count } = await supabase
+        .from("challenge_participants")
+        .select("id", { count: "exact", head: true })
+        .eq("patient_id", patientId);
+
+      hasChallenges = (count ?? 0) > 0;
+    }
   }
 
   return (
@@ -37,7 +51,7 @@ export default async function PatientRootLayout({
           : undefined
       }
     >
-      <PatientLayout isAuthenticated={isAuthenticated}>
+      <PatientLayout isAuthenticated={isAuthenticated} hasChallenges={hasChallenges}>
         {children}
       </PatientLayout>
       <PWAInstallPrompt />

--- a/src/components/layout/patient-layout.tsx
+++ b/src/components/layout/patient-layout.tsx
@@ -75,11 +75,18 @@ const authenticatedNavItems = [
 interface PatientLayoutProps {
   children: React.ReactNode;
   isAuthenticated?: boolean;
+  hasChallenges?: boolean;
 }
 
-export function PatientLayout({ children, isAuthenticated }: PatientLayoutProps) {
+export function PatientLayout({ children, isAuthenticated, hasChallenges }: PatientLayoutProps) {
   const pathname = usePathname();
-  const navItems = isAuthenticated ? authenticatedNavItems : publicNavItems;
+
+  // Filter out challenges if patient has no challenges
+  const navItems = isAuthenticated
+    ? authenticatedNavItems.filter(item =>
+        item.href !== "/patient/challenges" || hasChallenges
+      )
+    : publicNavItems;
 
   const isActive = (href: string) => {
     if (href === "/patient" || href === "/patient/dashboard") {


### PR DESCRIPTION
## Summary
- Only display the "Desafios" (Challenges) navigation item in the patient portal when the patient is enrolled in at least one challenge
- Improves UX by hiding irrelevant navigation for patients without challenges

## Changes
- **src/app/patient/layout.tsx**: Added check for challenge participation count
- **src/components/layout/patient-layout.tsx**: Added `hasChallenges` prop and filter logic for navigation items

## Test plan
- [ ] Login as a patient without challenges → "Desafios" tab should NOT appear
- [ ] Login as a patient with challenges → "Desafios" tab should appear
- [ ] Verify navigation works correctly on both desktop sidebar and mobile bottom nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)