### PR TITLE
feat: AI-powered anamnesis analysis with insights

### DIFF
--- a/src/app/(nutri)/patients/[id]/anamnesis/[reportId]/page.tsx
+++ b/src/app/(nutri)/patients/[id]/anamnesis/[reportId]/page.tsx
@@ -23,6 +23,8 @@ import {
   Brain,
   Loader2,
 } from "lucide-react";
+import { AnamnesisInsightsPanel } from "../_components/anamnesis-insights";
+import type { AnamnesisInsights } from "@/lib/ai/analyze-anamnesis";
 import { toast } from "sonner";
 import { useAutoSave } from "@/hooks/use-auto-save";
 import type {
@@ -113,6 +115,7 @@ export default function AnamnesisReviewPage({ params }: PageProps) {
       ...changes,
       social_history: changes.social_history as any,
       dietary_history: changes.dietary_history as any,
+      ai_insights: changes.ai_insights as any,
     };
 
     const { error } = await supabase
@@ -347,6 +350,12 @@ export default function AnamnesisReviewPage({ params }: PageProps) {
           )}
         </Card>
       )}
+
+      {/* AI Insights */}
+      <AnamnesisInsightsPanel
+        reportId={reportId}
+        initialInsights={(report.ai_insights as unknown as AnamnesisInsights) ?? null}
+      />
 
       {/* Main Content */}
       <div className="grid gap-6 lg:grid-cols-2">

--- a/src/app/(nutri)/patients/[id]/anamnesis/_components/anamnesis-insights.tsx
+++ b/src/app/(nutri)/patients/[id]/anamnesis/_components/anamnesis-insights.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Sparkles,
+  Loader2,
+  AlertTriangle,
+  Lightbulb,
+  TrendingUp,
+  ShieldAlert,
+  RefreshCw,
+} from "lucide-react";
+import type { AnamnesisInsights } from "@/lib/ai/analyze-anamnesis";
+
+interface AnamnesisInsightsProps {
+  reportId: string;
+  initialInsights: AnamnesisInsights | null;
+}
+
+export function AnamnesisInsightsPanel({
+  reportId,
+  initialInsights,
+}: AnamnesisInsightsProps) {
+  const [insights, setInsights] = useState<AnamnesisInsights | null>(initialInsights);
+  const [isAnalyzing, setIsAnalyzing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleAnalyze() {
+    setIsAnalyzing(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/anamnesis/analyze", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reportId }),
+      });
+
+      if (!response.ok) {
+        throw new Error("Falha na análise");
+      }
+
+      const data = await response.json();
+      setInsights(data.insights);
+    } catch {
+      setError("Erro ao gerar análise. Tente novamente.");
+    } finally {
+      setIsAnalyzing(false);
+    }
+  }
+
+  if (!insights) {
+    return (
+      <Card className="border-dashed">
+        <CardContent className="flex flex-col items-center justify-center py-8">
+          <Sparkles className="h-10 w-10 text-muted-foreground mb-3" />
+          <h3 className="font-semibold mb-1">Análise com IA</h3>
+          <p className="text-sm text-muted-foreground text-center max-w-sm mb-4">
+            Gere insights automáticos sobre esta anamnese: pontos de atenção,
+            padrões alimentares e sugestões de conduta.
+          </p>
+          {error && (
+            <p className="text-sm text-destructive mb-3">{error}</p>
+          )}
+          <Button onClick={handleAnalyze} disabled={isAnalyzing}>
+            {isAnalyzing ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Analisando...
+              </>
+            ) : (
+              <>
+                <Sparkles className="mr-2 h-4 w-4" />
+                Gerar Análise
+              </>
+            )}
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base flex items-center gap-2">
+            <Sparkles className="h-4 w-4 text-primary" />
+            Análise com IA
+          </CardTitle>
+          <div className="flex items-center gap-2">
+            <Badge variant="outline" className="text-xs">
+              {insights.model_used}
+            </Badge>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={handleAnalyze}
+              disabled={isAnalyzing}
+              title="Regenerar análise"
+            >
+              {isAnalyzing ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <RefreshCw className="h-3.5 w-3.5" />
+              )}
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        {error && (
+          <p className="text-sm text-destructive">{error}</p>
+        )}
+
+        {/* Summary */}
+        <div className="rounded-lg bg-primary/5 p-4">
+          <p className="text-sm font-medium text-primary mb-1">Resumo</p>
+          <p className="text-sm">{insights.summary}</p>
+        </div>
+
+        {/* Attention Points */}
+        <InsightSection
+          icon={<AlertTriangle className="h-4 w-4 text-amber-500" />}
+          title="Pontos de Atenção"
+          items={insights.attention_points}
+        />
+
+        {/* Dietary Patterns */}
+        <InsightSection
+          icon={<TrendingUp className="h-4 w-4 text-sky-500" />}
+          title="Padrões Alimentares"
+          items={insights.dietary_patterns}
+        />
+
+        {/* Suggestions */}
+        <InsightSection
+          icon={<Lightbulb className="h-4 w-4 text-emerald-500" />}
+          title="Sugestões de Conduta"
+          items={insights.suggestions}
+        />
+
+        {/* Risk Factors */}
+        <InsightSection
+          icon={<ShieldAlert className="h-4 w-4 text-rose-500" />}
+          title="Fatores de Risco"
+          items={insights.risk_factors}
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+function InsightSection({
+  icon,
+  title,
+  items,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  items: string[];
+}) {
+  if (!items.length || (items.length === 1 && items[0] === "Dados insuficientes para análise")) {
+    return null;
+  }
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-2">
+        {icon}
+        <p className="text-sm font-medium">{title}</p>
+      </div>
+      <ul className="space-y-1.5 pl-6">
+        {items.map((item, i) => (
+          <li key={i} className="text-sm text-muted-foreground list-disc">
+            {item}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/api/anamnesis/analyze/route.ts
+++ b/src/app/api/anamnesis/analyze/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { analyzeAnamnesis } from "@/lib/ai/analyze-anamnesis";
+import type { AnamnesisReport } from "@/types/anamnesis";
+
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { reportId } = await request.json();
+
+    if (!reportId) {
+      return NextResponse.json(
+        { error: "reportId is required" },
+        { status: 400 }
+      );
+    }
+
+    // Fetch the report (RLS ensures only the owner nutri can access)
+    const { data: report, error: fetchError } = await supabase
+      .from("anamnesis_reports")
+      .select(
+        "chief_complaint, history_present_illness, past_medical_history, family_history, social_history, dietary_history, current_medications, supplements, goals, observations"
+      )
+      .eq("id", reportId)
+      .eq("nutri_id", user.id)
+      .single();
+
+    if (fetchError || !report) {
+      return NextResponse.json(
+        { error: "Report not found" },
+        { status: 404 }
+      );
+    }
+
+    // Cast the Supabase Json types to the expected format
+    const reportData = report as unknown as Pick<
+      AnamnesisReport,
+      | "chief_complaint"
+      | "history_present_illness"
+      | "past_medical_history"
+      | "family_history"
+      | "social_history"
+      | "dietary_history"
+      | "current_medications"
+      | "supplements"
+      | "goals"
+      | "observations"
+    >;
+
+    // Generate AI insights
+    const insights = await analyzeAnamnesis(reportData);
+
+    // Save insights to the report
+    const { error: updateError } = await supabase
+      .from("anamnesis_reports")
+      .update({ ai_insights: JSON.parse(JSON.stringify(insights)) })
+      .eq("id", reportId);
+
+    if (updateError) {
+      throw updateError;
+    }
+
+    return NextResponse.json({
+      success: true,
+      insights,
+    });
+  } catch (error) {
+    console.error("Error analyzing anamnesis:", error);
+    return NextResponse.json(
+      { error: "Failed to analyze anamnesis" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/ai/analyze-anamnesis.ts
+++ b/src/lib/ai/analyze-anamnesis.ts
@@ -1,0 +1,116 @@
+import { getAnthropicClient } from "./anthropic";
+import type { AnamnesisReport } from "@/types/anamnesis";
+
+export interface AnamnesisInsights {
+  summary: string;
+  attention_points: string[];
+  dietary_patterns: string[];
+  suggestions: string[];
+  risk_factors: string[];
+  analyzed_at: string;
+  model_used: string;
+}
+
+const MODEL_ID = "claude-sonnet-4-20250514";
+
+const ANALYSIS_PROMPT = `Você é um nutricionista clínico experiente analisando dados de uma anamnese nutricional.
+
+Com base nos dados estruturados abaixo, gere uma análise inteligente para ajudar o nutricionista responsável.
+
+DADOS DA ANAMNESE:
+{data}
+
+INSTRUÇÕES:
+1. Gere um RESUMO EXECUTIVO conciso (2-3 frases) do caso
+2. Liste PONTOS DE ATENÇÃO que o nutricionista deve considerar (condições médicas, medicamentos que afetam nutrição, etc.)
+3. Identifique PADRÕES ALIMENTARES relevantes (positivos e negativos)
+4. Faça SUGESTÕES práticas para a conduta nutricional
+5. Liste FATORES DE RISCO nutricionais identificados
+
+FORMATO DE SAÍDA (JSON válido):
+{
+  "summary": "Resumo executivo do caso em 2-3 frases",
+  "attention_points": ["Ponto de atenção 1", "Ponto de atenção 2"],
+  "dietary_patterns": ["Padrão identificado 1", "Padrão identificado 2"],
+  "suggestions": ["Sugestão 1", "Sugestão 2"],
+  "risk_factors": ["Fator de risco 1", "Fator de risco 2"]
+}
+
+REGRAS:
+- Seja específico e baseado nos dados fornecidos
+- Use linguagem técnica mas acessível
+- Cada array deve ter entre 2 e 6 itens
+- Se não houver dados suficientes para um campo, inclua ["Dados insuficientes para análise"]
+- NÃO invente informações que não estejam nos dados
+
+Responda APENAS com o JSON, sem texto adicional.`;
+
+export async function analyzeAnamnesis(
+  report: Pick<
+    AnamnesisReport,
+    | "chief_complaint"
+    | "history_present_illness"
+    | "past_medical_history"
+    | "family_history"
+    | "social_history"
+    | "dietary_history"
+    | "current_medications"
+    | "supplements"
+    | "goals"
+    | "observations"
+  >
+): Promise<AnamnesisInsights> {
+  const anthropic = getAnthropicClient();
+
+  const dataStr = JSON.stringify(
+    {
+      queixa_principal: report.chief_complaint,
+      historia_doenca_atual: report.history_present_illness,
+      antecedentes_pessoais: report.past_medical_history,
+      historico_familiar: report.family_history,
+      historico_social: report.social_history,
+      historico_alimentar: report.dietary_history,
+      medicamentos: report.current_medications,
+      suplementos: report.supplements,
+      objetivos: report.goals,
+      observacoes: report.observations,
+    },
+    null,
+    2
+  );
+
+  const prompt = ANALYSIS_PROMPT.replace("{data}", dataStr);
+
+  const response = await anthropic.messages.create({
+    model: MODEL_ID,
+    max_tokens: 2048,
+    messages: [{ role: "user", content: prompt }],
+  });
+
+  const textContent = response.content.find((block) => block.type === "text");
+  if (!textContent || textContent.type !== "text") {
+    throw new Error("No text response from AI model");
+  }
+
+  const jsonMatch = textContent.text.trim().match(/\{[\s\S]*\}/);
+  if (!jsonMatch) {
+    throw new Error("No JSON object found in AI response");
+  }
+
+  const parsed = JSON.parse(jsonMatch[0]);
+
+  return {
+    summary: parsed.summary || "Análise não disponível",
+    attention_points: normalizeArray(parsed.attention_points),
+    dietary_patterns: normalizeArray(parsed.dietary_patterns),
+    suggestions: normalizeArray(parsed.suggestions),
+    risk_factors: normalizeArray(parsed.risk_factors),
+    analyzed_at: new Date().toISOString(),
+    model_used: MODEL_ID,
+  };
+}
+
+function normalizeArray(arr: unknown): string[] {
+  if (!Array.isArray(arr)) return ["Dados insuficientes para análise"];
+  return arr.filter((item): item is string => typeof item === "string" && item.trim() !== "");
+}

--- a/src/types/anamnesis.ts
+++ b/src/types/anamnesis.ts
@@ -50,6 +50,7 @@ export interface AnamnesisReport {
   audio_duration_seconds: number | null;
   ai_model_used: string | null;
   confidence_score: number | null;
+  ai_insights: Record<string, unknown> | null;
 
   // Workflow
   status: AnamnesisStatus;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -16,6 +16,7 @@ export type Database = {
     Tables: {
       anamnesis_reports: {
         Row: {
+          ai_insights: Json | null
           ai_model_used: string | null
           approved_at: string | null
           audio_duration_seconds: number | null
@@ -41,6 +42,7 @@ export type Database = {
           updated_at: string
         }
         Insert: {
+          ai_insights?: Json | null
           ai_model_used?: string | null
           approved_at?: string | null
           audio_duration_seconds?: number | null
@@ -66,6 +68,7 @@ export type Database = {
           updated_at?: string
         }
         Update: {
+          ai_insights?: Json | null
           ai_model_used?: string | null
           approved_at?: string | null
           audio_duration_seconds?: number | null

--- a/supabase/migrations/20260318000003_anamnesis_ai_insights.sql
+++ b/supabase/migrations/20260318000003_anamnesis_ai_insights.sql
@@ -1,0 +1,8 @@
+-- Issue #10: Add AI insights/analysis field to anamnesis_reports
+-- Stores structured AI-generated insights, suggestions, and recommendations.
+
+alter table anamnesis_reports
+  add column if not exists ai_insights jsonb default null;
+
+comment on column anamnesis_reports.ai_insights is
+  'AI-generated insights: summary, attention_points, dietary_patterns, suggestions, risk_factors';


### PR DESCRIPTION
Closes #10

## Summary

- Add "Gerar Análise" button on the anamnesis review page
- AI generates structured insights using Claude Sonnet: executive summary, attention points, dietary patterns, clinical suggestions, and risk factors
- Insights are saved to the DB and displayed in a dedicated panel
- Regeneration supported via refresh button

## New files

| File | Purpose |
|------|---------|
| `src/lib/ai/analyze-anamnesis.ts` | AI analysis function with structured prompt |
| `src/app/api/anamnesis/analyze/route.ts` | POST endpoint for analysis |
| `src/app/(nutri)/patients/[id]/anamnesis/_components/anamnesis-insights.tsx` | Insights panel component |
| `supabase/migrations/20260318000003_anamnesis_ai_insights.sql` | Add `ai_insights` jsonb column |

## Test plan

- [ ] "Gerar Análise" button appears on anamnesis review page
- [ ] Clicking generates insights via Claude Sonnet API
- [ ] Insights display correctly: summary, attention points, patterns, suggestions, risks
- [ ] Insights persist after page reload
- [ ] "Regenerar" button re-generates analysis
- [ ] Loading state shows during analysis
- [ ] Error state shows on failure
- [ ] Non-owner nutri cannot analyze another's reports (RLS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)