### PR TITLE
fix: date mutation bugs in organization queries

### DIFF
--- a/src/lib/queries/organization.ts
+++ b/src/lib/queries/organization.ts
@@ -698,9 +698,9 @@ export async function getOrganizationDashboardStats(
     .is("accepted_at", null);
 
   // Get today's appointments count for the org
-  const today = new Date();
-  const startOfDay = new Date(today.setHours(0, 0, 0, 0)).toISOString();
-  const endOfDay = new Date(today.setHours(23, 59, 59, 999)).toISOString();
+  const now1 = new Date();
+  const startOfDay = new Date(now1.getFullYear(), now1.getMonth(), now1.getDate(), 0, 0, 0).toISOString();
+  const endOfDay = new Date(now1.getFullYear(), now1.getMonth(), now1.getDate(), 23, 59, 59, 999).toISOString();
 
   const { count: totalAppointmentsToday } = await supabase
     .from("appointments")
@@ -751,9 +751,9 @@ export async function getOrganizationNutrisWithSchedule(
   }
 
   // Get today's date range
-  const today = new Date();
-  const startOfDay = new Date(today.setHours(0, 0, 0, 0)).toISOString();
-  const endOfDay = new Date(today.setHours(23, 59, 59, 999)).toISOString();
+  const now2 = new Date();
+  const startOfDay = new Date(now2.getFullYear(), now2.getMonth(), now2.getDate(), 0, 0, 0).toISOString();
+  const endOfDay = new Date(now2.getFullYear(), now2.getMonth(), now2.getDate(), 23, 59, 59, 999).toISOString();
 
   // Get appointments for each nutri
   const nutrisWithAppointments = await Promise.all(


### PR DESCRIPTION
Closes #51

## Summary

Fix `setHours()` mutation bug in `src/lib/queries/organization.ts` (2 occurrences).

**Before (buggy):**
```js
const today = new Date();
const startOfDay = new Date(today.setHours(0, 0, 0, 0));  // mutates today
const endOfDay = new Date(today.setHours(23, 59, 59, 999)); // today already modified!
```

**After (safe):**
```js
const now = new Date();
const startOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0);
const endOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59, 999);
```

Other files mentioned in the issue (conflict-checker, schedule page) were checked and found safe — they already use separate Date objects.

## Test plan

- [ ] Organization dashboard shows correct "today's appointments" count
- [ ] Nutri list shows correct appointment counts per day

🤖 Generated with [Claude Code](https://claude.com/claude-code)