### PR TITLE
fix: race conditions in token creation and invite acceptance

### DIFF
--- a/src/app/api/invite/accept/route.ts
+++ b/src/app/api/invite/accept/route.ts
@@ -59,31 +59,20 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Check if already a member
-    const { data: existingMember } = await serviceClient
-      .from("organization_members")
-      .select("id")
-      .eq("organization_id", invite.organization_id as string)
-      .eq("user_id", user.id)
-      .single();
-
-    if (existingMember) {
-      return NextResponse.json(
-        { error: "Você já é membro desta organização" },
-        { status: 400 }
-      );
-    }
-
-    // Add user as member
+    // Add user as member (upsert to handle race conditions)
+    // The unique constraint (organization_id, user_id) prevents duplicates
     const { error: memberError } = await serviceClient
       .from("organization_members")
-      .insert({
-        organization_id: invite.organization_id as string,
-        user_id: user.id,
-        role: invite.role as "admin" | "nutri" | "receptionist" | "patient",
-        status: "active",
-        accepted_at: new Date().toISOString(),
-      });
+      .upsert(
+        {
+          organization_id: invite.organization_id as string,
+          user_id: user.id,
+          role: invite.role as "admin" | "nutri" | "receptionist" | "patient",
+          status: "active",
+          accepted_at: new Date().toISOString(),
+        },
+        { onConflict: "organization_id,user_id", ignoreDuplicates: true }
+      );
 
     if (memberError) {
       console.error("Error adding member:", memberError);

--- a/src/lib/patient-token.ts
+++ b/src/lib/patient-token.ts
@@ -22,20 +22,17 @@ export async function createPatientToken(patientId: string): Promise<string> {
   const expiresAt = new Date();
   expiresAt.setDate(expiresAt.getDate() + TOKEN_EXPIRY_DAYS);
 
-  // Delete any existing tokens for this patient
-  await supabase
-    .from("patient_tokens")
-    .delete()
-    .eq("patient_id", patientId);
-
-  // Create new token
+  // Upsert token (avoids race condition with concurrent delete+insert)
   const { error } = await supabase
     .from("patient_tokens")
-    .insert({
-      patient_id: patientId,
-      token,
-      expires_at: expiresAt.toISOString(),
-    });
+    .upsert(
+      {
+        patient_id: patientId,
+        token,
+        expires_at: expiresAt.toISOString(),
+      },
+      { onConflict: "patient_id" }
+    );
 
   if (error) {
     throw new Error(`Failed to create patient token: ${error.message}`);

--- a/supabase/migrations/20260318000004_race_condition_fixes.sql
+++ b/supabase/migrations/20260318000004_race_condition_fixes.sql
@@ -1,0 +1,6 @@
+-- Fix #52: Race condition fixes
+
+-- Add unique constraint on patient_tokens.patient_id for upsert support
+-- (currently allows multiple tokens per patient, causing delete+insert race condition)
+alter table patient_tokens
+  add constraint patient_tokens_patient_id_unique unique (patient_id);


### PR DESCRIPTION
Closes #52

## Summary

- **Patient token**: Replace `delete → insert` with `upsert(onConflict: "patient_id")` to prevent concurrent requests from deleting each other's tokens
- **Invite accept**: Replace check-then-insert with `upsert(ignoreDuplicates: true)` to handle concurrent invite acceptances gracefully
- Add `UNIQUE(patient_id)` constraint on `patient_tokens` table for upsert support

The org slug already has a unique constraint, and `organization_members(organization_id, user_id)` unique constraint already exists.

## Test plan

- [ ] Creating a patient share link works (token generated)
- [ ] Concurrent token creation doesn't fail
- [ ] Accepting an invite works correctly
- [ ] Double-accepting same invite doesn't create duplicate members

🤖 Generated with [Claude Code](https://claude.com/claude-code)