### PR TITLE
fix: null safety in scheduling and body fat calculation

### DIFF
--- a/src/lib/anthropometry-calculations.ts
+++ b/src/lib/anthropometry-calculations.ts
@@ -107,10 +107,12 @@ function calculateBodyFatFromDensity(
 
   const bodyFatPercentage = ((4.95 / bodyDensity) - 4.5) * 100;
 
-  // Clamp to reasonable values (0-70%)
-  const clampedValue = Math.max(0, Math.min(70, bodyFatPercentage));
+  // Return null for out-of-range values (likely bad input data)
+  if (bodyFatPercentage < 0 || bodyFatPercentage > 70) {
+    return null;
+  }
 
-  return Math.round(clampedValue * 100) / 100; // Round to 2 decimal places
+  return Math.round(bodyFatPercentage * 100) / 100;
 }
 
 /**

--- a/src/lib/scheduling/available-slots.ts
+++ b/src/lib/scheduling/available-slots.ts
@@ -62,7 +62,7 @@ export async function getAvailableSlotsForDate({
       const hasAppointment = appointments.some((appointment) => {
         const appointmentStart = new Date(appointment.scheduled_at);
         const appointmentEnd = new Date(
-          appointmentStart.getTime() + appointment.duration_minutes * 60 * 1000
+          appointmentStart.getTime() + (appointment.duration_minutes ?? 60) * 60 * 1000
         );
         return slot.start < appointmentEnd && slot.end > appointmentStart;
       });


### PR DESCRIPTION
Closes #53

## Summary

- **duration_minutes**: Add `?? 60` fallback in `available-slots.ts` to prevent NaN when appointment duration is null
- **Body fat calculation**: Return `null` instead of silently clamping values outside 0-70% range, so the UI can show "N/A" instead of a misleading number

Two issues from the ticket were already handled:
- Auth check in anamnesis wizard already runs before DB insert
- Gender null check in anthropometry form already has `if (!patient.gender) return null`

## Test plan

- [ ] Available slots calculation works when appointment has null duration
- [ ] Body fat shows "N/A" when skinfold data produces out-of-range values
- [ ] Normal body fat calculations still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)