### PR TITLE
refactor: extract shared patient queries and export helpers

### DIFF
--- a/src/lib/queries/export-helpers.ts
+++ b/src/lib/queries/export-helpers.ts
@@ -1,0 +1,43 @@
+import { createClient } from "@/lib/supabase/server";
+import type { Patient, Measurement } from "@/types/database";
+
+/**
+ * Shared validation and data fetching for export routes (PDF/CSV).
+ * Eliminates ~30 lines of duplicated auth + patient validation.
+ */
+export async function getExportData(patientId: string): Promise<{
+  error?: string;
+  status?: number;
+  patient?: Patient;
+  measurements?: Measurement[];
+}> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "Não autenticado", status: 401 };
+  }
+
+  const { data: patient } = await supabase
+    .from("patients")
+    .select("*")
+    .eq("id", patientId)
+    .single();
+
+  if (!patient) {
+    return { error: "Paciente não encontrado", status: 404 };
+  }
+
+  const { data: measurements } = await supabase
+    .from("measurements")
+    .select("*")
+    .eq("patient_id", patientId)
+    .order("measured_at", { ascending: true });
+
+  return {
+    patient: patient as Patient,
+    measurements: (measurements ?? []) as Measurement[],
+  };
+}

--- a/src/lib/queries/patients.ts
+++ b/src/lib/queries/patients.ts
@@ -1,0 +1,79 @@
+import { createClient } from "@/lib/supabase/server";
+import type { Patient } from "@/types/database";
+
+/**
+ * Get a single patient by ID. RLS handles authorization.
+ */
+export async function getPatientById(id: string): Promise<Patient | null> {
+  const supabase = await createClient();
+
+  const { data } = await supabase
+    .from("patients")
+    .select("*")
+    .eq("id", id)
+    .single();
+
+  return data as Patient | null;
+}
+
+/**
+ * Get all patients for the current user. For receptionists, RLS returns org patients.
+ */
+export async function getPatientsList(options?: {
+  searchQuery?: string;
+  page?: number;
+  pageSize?: number;
+}): Promise<{ patients: Patient[]; totalCount: number }> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) return { patients: [], totalCount: 0 };
+
+  const page = options?.page ?? 1;
+  const pageSize = options?.pageSize ?? 50;
+
+  let query = supabase
+    .from("patients")
+    .select("*", { count: "exact" })
+    .order("created_at", { ascending: false })
+    .range((page - 1) * pageSize, page * pageSize - 1);
+
+  if (options?.searchQuery) {
+    query = query.or(
+      `full_name.ilike.%${options.searchQuery}%,email.ilike.%${options.searchQuery}%,phone.ilike.%${options.searchQuery}%`
+    );
+  }
+
+  const { data, count } = await query;
+
+  return { patients: (data ?? []) as Patient[], totalCount: count ?? 0 };
+}
+
+/**
+ * Get patient stats (counts) for the detail page. All queries run in parallel.
+ */
+export async function getPatientStats(patientId: string) {
+  const supabase = await createClient();
+
+  const [
+    { count: mealPlansCount },
+    { count: appointmentsCount },
+    { count: measurementsCount },
+    { count: anamnesisCount },
+    { count: anthropometryCount },
+  ] = await Promise.all([
+    supabase.from("meal_plans").select("*", { count: "exact", head: true }).eq("patient_id", patientId),
+    supabase.from("appointments").select("*", { count: "exact", head: true }).eq("patient_id", patientId),
+    supabase.from("measurements").select("*", { count: "exact", head: true }).eq("patient_id", patientId),
+    supabase.from("anamnesis_reports").select("*", { count: "exact", head: true }).eq("patient_id", patientId),
+    supabase.from("anthropometry_assessments").select("*", { count: "exact", head: true }).eq("patient_id", patientId),
+  ]);
+
+  return {
+    mealPlans: mealPlansCount ?? 0,
+    appointments: appointmentsCount ?? 0,
+    measurements: measurementsCount ?? 0,
+    anamnesis: anamnesisCount ?? 0,
+    anthropometry: anthropometryCount ?? 0,
+  };
+}


### PR DESCRIPTION
Closes #64

## Summary

- Create `src/lib/queries/patients.ts` with 3 reusable query functions
- Create `src/lib/queries/export-helpers.ts` for shared export route validation
- Refactor patient detail page to use `getPatientById()` and `getPatientStats()` from the shared module

The remaining inline queries in other pages can be migrated incrementally.

## Test plan

- [ ] Patient detail page loads correctly with shared queries
- [ ] Stats counts match the original implementation
- [ ] No regression in other patient pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)