### PR TITLE
feat: invite-only account creation + fix admin role bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,12 @@ node_modules/
 /playwright/.cache/
 /playwright/.auth/
 
+# Playwright MCP
+.playwright-mcp/
+
+# Notes
+QUESTIONS.md
+
 # Auto Claude data directory
 .auto-claude/
 

--- a/scripts/seed-test-data.ts
+++ b/scripts/seed-test-data.ts
@@ -38,7 +38,7 @@ interface TestUser {
   email: string;
   password: string;
   full_name: string;
-  profile_role: 'nutri' | 'patient';
+  profile_role: 'nutri' | 'patient' | null;
   user_type?: 'invite' | 'patient';
 }
 
@@ -47,7 +47,8 @@ const TEST_USERS: Record<string, TestUser> = {
     email: 'test-admin@example.com',
     password: 'TestPassword123!',
     full_name: 'Test Admin',
-    profile_role: 'nutri',
+    profile_role: null,
+    user_type: 'invite',
   },
   nutri: {
     email: 'test-nutri@example.com',
@@ -59,26 +60,28 @@ const TEST_USERS: Record<string, TestUser> = {
     email: 'test-receptionist@example.com',
     password: 'TestPassword123!',
     full_name: 'Test Recepcionista',
-    profile_role: 'nutri',
+    profile_role: null,
+    user_type: 'invite',
   },
   patient: {
     email: 'test-patient@example.com',
     password: 'TestPassword123!',
     full_name: 'Test Paciente',
-    profile_role: 'patient',
+    profile_role: null,
     user_type: 'patient',
   },
   noOrg: {
     email: 'test-noorg@example.com',
     password: 'TestPassword123!',
     full_name: 'Test Sem Org',
-    profile_role: 'nutri',
+    profile_role: null,
+    user_type: 'invite',
   },
   invited: {
     email: 'test-invited@example.com',
     password: 'TestPassword123!',
     full_name: 'Test Convidado',
-    profile_role: 'nutri',
+    profile_role: null,
     user_type: 'invite',
   },
 };
@@ -100,6 +103,30 @@ const TEST_INVITES = {
     role: 'receptionist',
     token: 'test-expired-invite-token-e2e-99999',
     expires_at: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+  },
+  adminInvite: {
+    email: 'test-admin-invite@example.com',
+    role: 'admin',
+    token: 'test-admin-invite-token-e2e-admin',
+    expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  nutriInvite: {
+    email: 'test-nutri-invite@example.com',
+    role: 'nutri',
+    token: 'test-nutri-invite-token-e2e-nutri',
+    expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  receptionistInvite: {
+    email: 'test-recep-invite@example.com',
+    role: 'receptionist',
+    token: 'test-recep-invite-token-e2e-recep',
+    expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  patientInvite: {
+    email: 'test-patient-invite@example.com',
+    role: 'patient',
+    token: 'test-patient-invite-token-e2e-patient',
+    expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
   },
 };
 
@@ -124,7 +151,7 @@ async function createTestUser(userData: TestUser) {
       id: existingUser.id,
       email: userData.email,
       full_name: userData.full_name,
-      role: userData.profile_role,
+      ...(userData.profile_role !== null ? { role: userData.profile_role } : {}),
     }, {
       onConflict: 'id',
     });
@@ -160,7 +187,7 @@ async function createTestUser(userData: TestUser) {
       id: data.user.id,
       email: userData.email,
       full_name: userData.full_name,
-      role: userData.profile_role,
+      ...(userData.profile_role !== null ? { role: userData.profile_role } : {}),
     });
 
     if (profileError) {
@@ -703,6 +730,10 @@ async function main() {
   console.log('\nCreating test invites:');
   await createTestInvite(org.id, nutriUser.id, TEST_INVITES.pending);
   await createTestInvite(org.id, nutriUser.id, TEST_INVITES.expired);
+  await createTestInvite(org.id, nutriUser.id, TEST_INVITES.adminInvite);
+  await createTestInvite(org.id, nutriUser.id, TEST_INVITES.nutriInvite);
+  await createTestInvite(org.id, nutriUser.id, TEST_INVITES.receptionistInvite);
+  await createTestInvite(org.id, nutriUser.id, TEST_INVITES.patientInvite);
 
   console.log('\n✅ Test data seeded successfully!\n');
   console.log('Test credentials:');

--- a/src/app/api/invite/accept/route.ts
+++ b/src/app/api/invite/accept/route.ts
@@ -59,7 +59,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Ensure profile exists (may be missing if user was created before trigger)
+    // Profile should exist via handle_new_user() trigger
     const { data: existingProfile } = await serviceClient
       .from("profiles")
       .select("id")
@@ -67,27 +67,11 @@ export async function POST(request: NextRequest) {
       .single();
 
     if (!existingProfile) {
-      const { error: profileError } = await serviceClient
-        .from("profiles")
-        .insert({
-          id: user.id,
-          email: user.email!,
-          full_name:
-            user.user_metadata?.full_name ?? user.email?.split("@")[0] ?? "Usuário",
-          role: "nutri",
-        });
-
-      if (profileError) {
-        console.error("Error creating profile:", profileError);
-        return NextResponse.json(
-          { error: "Erro ao criar perfil do usuário" },
-          { status: 500 }
-        );
-      }
+      console.warn(`Profile missing for user ${user.id} — trigger may have failed`);
     }
 
     // Add user as member (upsert to handle race conditions)
-    // The unique constraint (organization_id, user_id) prevents duplicates
+    // On conflict: UPDATE role/status so invite role is always applied
     const { error: memberError } = await serviceClient
       .from("organization_members")
       .upsert(
@@ -98,7 +82,7 @@ export async function POST(request: NextRequest) {
           status: "active",
           accepted_at: new Date().toISOString(),
         },
-        { onConflict: "organization_id,user_id", ignoreDuplicates: true }
+        { onConflict: "organization_id,user_id" }
       );
 
     if (memberError) {

--- a/src/app/auth/actions.ts
+++ b/src/app/auth/actions.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
-import { createClient } from "@/lib/supabase/server";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
 
 export type AuthState = {
   error?: string;
@@ -87,7 +87,6 @@ export async function signup(
   const email = formData.get("email") as string;
   const password = formData.get("password") as string;
   const fullName = formData.get("full_name") as string;
-  const userType = formData.get("user_type") as string | null;
 
   if (!email || !password || !fullName) {
     return { error: "Todos os campos são obrigatórios" };
@@ -97,13 +96,28 @@ export async function signup(
     return { error: "A senha deve ter pelo menos 6 caracteres" };
   }
 
+  // Invite-only guard: verify email has a pending invite
+  const serviceClient = createServiceClient();
+  const { data: pendingInvite } = await serviceClient
+    .from("organization_invites")
+    .select("id, token")
+    .eq("email", email.toLowerCase())
+    .is("accepted_at", null)
+    .gt("expires_at", new Date().toISOString())
+    .limit(1)
+    .single();
+
+  if (!pendingInvite) {
+    return { error: "Cadastro disponível apenas por convite. Solicite um convite ao administrador da sua clínica." };
+  }
+
   const { data, error } = await supabase.auth.signUp({
     email,
     password,
     options: {
       data: {
         full_name: fullName,
-        ...(userType && { user_type: userType }),
+        user_type: "invite",
       },
     },
   });
@@ -133,26 +147,19 @@ export async function signup(
   }
 
   // Profile is created automatically by database trigger (handle_new_user)
-  // No need to manually insert here
 
   // Check if email confirmation is required (user exists but session is null)
   if (!data.session) {
-    // Email confirmation is required - don't redirect, show success message
     return {
       success: true,
       error: undefined
     };
   }
 
-  const redirectTo = formData.get("redirect") as string;
   revalidatePath("/", "layout");
 
-  // Handle redirect if provided
-  if (redirectTo && redirectTo.startsWith("/")) {
-    redirect(redirectTo);
-  }
-
-  redirect("/dashboard");
+  // Redirect to the invite page for auto-accept
+  redirect(`/invite/${pendingInvite.token}`);
 }
 
 export async function logout() {

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -24,14 +24,6 @@ function LoginForm() {
   const inviteMode = searchParams.get("mode") === "signup";
   const [isSignup, setIsSignup] = useState(inviteMode);
 
-  // Detect user type based on redirect URL
-  // - /patient/ → patient signup (no profile needed)
-  // - /invite/ → invite signup (profile handled by invite acceptance)
-  // - otherwise → regular nutri signup
-  const isPatientSignup = redirectTo.includes("/patient/");
-  const isInviteSignup = redirectTo.includes("/invite/");
-  const userType = isPatientSignup ? "patient" : isInviteSignup ? "invite" : null;
-
   const [loginState, loginAction, loginPending] = useActionState(
     login,
     initialState
@@ -67,8 +59,6 @@ function LoginForm() {
         <form action={action} className="space-y-4">
           {/* Hidden field for redirect */}
           {redirectTo && <input type="hidden" name="redirect" value={redirectTo} />}
-          {/* Hidden field for user type (skip profile creation for patients and invites) */}
-          {userType && <input type="hidden" name="user_type" value={userType} />}
 
           {state.error && (
             <div className="rounded-xl bg-destructive/10 p-4 text-sm text-destructive">

--- a/src/app/invite/[token]/_components/auto-accept-invite.tsx
+++ b/src/app/invite/[token]/_components/auto-accept-invite.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Loader2 } from "lucide-react";
+import type { OrgRole } from "@/types/database";
+import { AcceptInviteButton } from "./accept-invite-button";
+
+interface AutoAcceptInviteProps {
+  token: string;
+  role: OrgRole;
+}
+
+function getRedirectPath(role: OrgRole): string {
+  switch (role) {
+    case "receptionist":
+      return "/schedule";
+    case "patient":
+      return "/patient/dashboard";
+    default:
+      return "/dashboard";
+  }
+}
+
+export function AutoAcceptInvite({ token, role }: AutoAcceptInviteProps) {
+  const router = useRouter();
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function accept() {
+      try {
+        const response = await fetch("/api/invite/accept", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ token }),
+        });
+
+        if (cancelled) return;
+
+        if (!response.ok) {
+          setFailed(true);
+          return;
+        }
+
+        router.push(getRedirectPath(role));
+        router.refresh();
+      } catch {
+        if (!cancelled) setFailed(true);
+      }
+    }
+
+    accept();
+    return () => { cancelled = true; };
+  }, [token, role, router]);
+
+  if (failed) {
+    return <AcceptInviteButton token={token} role={role} />;
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-3 py-4">
+      <Loader2 className="h-6 w-6 animate-spin text-primary" />
+      <p className="text-sm text-muted-foreground">Aceitando convite...</p>
+    </div>
+  );
+}

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -2,7 +2,9 @@ import { createClient } from "@/lib/supabase/server";
 import { getInviteByToken } from "@/lib/queries/organization";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Building2, AlertCircle } from "lucide-react";
+import type { OrgRole } from "@/types/database";
 import { AcceptInviteButton } from "./_components/accept-invite-button";
+import { AutoAcceptInvite } from "./_components/auto-accept-invite";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 
@@ -76,12 +78,21 @@ export default async function InvitePage({ params }: InvitePageProps) {
           </div>
 
           {isLoggedIn ? (
-            <div className="space-y-4">
-              <p className="text-sm text-center text-muted-foreground">
-                Logado como <strong>{user.email}</strong>
-              </p>
-              <AcceptInviteButton token={token} role={invite.role as any} />
-            </div>
+            user.email?.toLowerCase() === invite.email.toLowerCase() ? (
+              <div className="space-y-4">
+                <p className="text-sm text-center text-muted-foreground">
+                  Logado como <strong>{user.email}</strong>
+                </p>
+                <AutoAcceptInvite token={token} role={invite.role as OrgRole} />
+              </div>
+            ) : (
+              <div className="space-y-4">
+                <p className="text-sm text-center text-muted-foreground">
+                  Logado como <strong>{user.email}</strong>
+                </p>
+                <AcceptInviteButton token={token} role={invite.role as OrgRole} />
+              </div>
+            )
           ) : (
             <div className="space-y-4">
               <p className="text-sm text-center text-muted-foreground">

--- a/src/contexts/role-context.tsx
+++ b/src/contexts/role-context.tsx
@@ -130,9 +130,9 @@ export function RoleProvider({ children, initialRole }: RoleProviderProps) {
         return;
       }
 
-      // User has no organization - default to nutri role for backwards compatibility
+      // User has no organization
       setOrganizationId(null);
-      setRole("nutri");
+      setRole(null);
       setIsOwner(false);
     } catch (err) {
       setError(err instanceof Error ? err : new Error("Failed to fetch role"));

--- a/src/lib/queries/organization.ts
+++ b/src/lib/queries/organization.ts
@@ -523,56 +523,6 @@ export async function getInviteByToken(
   } as OrganizationInvite & { organization: Organization };
 }
 
-export async function acceptInvite(
-  token: string
-): Promise<{ error: string | null }> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return { error: "Usuário não autenticado" };
-  }
-
-  // Get invite
-  const invite = await getInviteByToken(token);
-
-  if (!invite) {
-    return { error: "Convite inválido ou expirado" };
-  }
-
-  // Add user as member
-  const { error: memberError } = await supabase
-    .from("organization_members")
-    .insert({
-      organization_id: invite.organization_id,
-      user_id: user.id,
-      role: invite.role,
-      invited_by: invite.invited_by,
-      status: "active",
-      accepted_at: new Date().toISOString(),
-    });
-
-  if (memberError) {
-    console.error("Error adding member:", memberError);
-    return { error: memberError.message };
-  }
-
-  // Mark invite as accepted
-  const { error: updateError } = await supabase
-    .from("organization_invites")
-    .update({ accepted_at: new Date().toISOString() })
-    .eq("id", invite.id);
-
-  if (updateError) {
-    console.error("Error updating invite:", updateError);
-    // Member was added, so don't return error
-  }
-
-  return { error: null };
-}
-
 // ============================================
 // Get Organization Nutris (for receptionist forms)
 // ============================================

--- a/supabase/migrations/20260401000001_invite_only_refactor.sql
+++ b/supabase/migrations/20260401000001_invite_only_refactor.sql
@@ -1,0 +1,90 @@
+-- Migration: Invite-Only Account Refactor
+-- 1. Make profiles.role nullable (role source of truth moves to organization_members)
+-- 2. Fix RLS policy that blocks admins from creating patients
+-- 3. Update handle_new_user() trigger to always create profile (with NULL role for invites)
+-- 4. Backfill profiles for users that were missing them
+
+-- ============================================
+-- 1. Make profiles.role nullable
+-- ============================================
+ALTER TABLE profiles ALTER COLUMN role DROP NOT NULL;
+ALTER TABLE profiles ALTER COLUMN role SET DEFAULT NULL;
+
+-- ============================================
+-- 2. Fix RLS: "Nutris can create patients" → "Clinical staff can create patients"
+-- The old policy checked profiles.role = 'nutri', blocking admins.
+-- New policy checks organization_members.role IN ('admin', 'nutri')
+-- with backward compat for legacy users without org membership.
+-- ============================================
+DROP POLICY IF EXISTS "Nutris can create patients" ON patients;
+
+CREATE POLICY "Clinical staff can create patients"
+  ON patients FOR INSERT
+  WITH CHECK (
+    auth.uid() = nutri_id
+    AND (
+      EXISTS (
+        SELECT 1 FROM organization_members
+        WHERE user_id = auth.uid()
+        AND role IN ('admin', 'nutri')
+        AND status = 'active'
+      )
+      OR EXISTS (
+        SELECT 1 FROM profiles
+        WHERE id = auth.uid()
+        AND role = 'nutri'
+      )
+    )
+  );
+
+-- ============================================
+-- 3. Update handle_new_user() trigger
+-- Always create a profile (needed for FK references throughout the app).
+-- For invite/patient signups: role = NULL (role comes from organization_members)
+-- For legacy direct signups: role = 'nutri' (backward compat, shouldn't happen in invite-only mode)
+-- ============================================
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER SET search_path = ''
+AS $$
+DECLARE
+  v_user_type text;
+BEGIN
+  v_user_type := new.raw_user_meta_data->>'user_type';
+
+  IF v_user_type IN ('patient', 'invite') THEN
+    INSERT INTO public.profiles (id, email, full_name, role)
+    VALUES (
+      new.id,
+      new.email,
+      coalesce(new.raw_user_meta_data->>'full_name', 'Usuário'),
+      NULL
+    );
+  ELSE
+    INSERT INTO public.profiles (id, email, full_name, role)
+    VALUES (
+      new.id,
+      new.email,
+      coalesce(new.raw_user_meta_data->>'full_name', 'Usuário'),
+      'nutri'::public.user_role
+    );
+  END IF;
+
+  RETURN new;
+END;
+$$;
+
+-- ============================================
+-- 4. Backfill profiles for users missing them
+-- (invite/patient users created before trigger was fixed)
+-- ============================================
+INSERT INTO public.profiles (id, email, full_name, role)
+SELECT
+  u.id,
+  u.email,
+  coalesce(u.raw_user_meta_data->>'full_name', 'Usuário'),
+  NULL
+FROM auth.users u
+LEFT JOIN public.profiles p ON p.id = u.id
+WHERE p.id IS NULL;

--- a/tests/auth/invite-signup-roles.spec.ts
+++ b/tests/auth/invite-signup-roles.spec.ts
@@ -1,0 +1,212 @@
+import { test, expect } from '@playwright/test';
+import { testInviteTokens } from '../fixtures/test-data';
+
+/**
+ * Per-role invite signup E2E tests.
+ *
+ * Each test verifies the full flow for a specific role:
+ *   1. Visit /invite/[token] (unauthenticated)
+ *   2. Click "Criar Conta" → signup form
+ *   3. Fill form and submit
+ *   4. Auto-accept invite → redirect to role-appropriate page
+ *
+ * IMPORTANT: These tests create real users and consume invites.
+ * Run `npx tsx scripts/seed-test-data.ts` before each test run to reset state.
+ */
+
+const ROLE_REDIRECTS: Record<string, RegExp> = {
+  admin: /\/(dashboard|patients|plans|organization)/,
+  nutri: /\/(dashboard|patients|plans)/,
+  receptionist: /\/(schedule|dashboard)/,
+  patient: /\/patient\/dashboard/,
+};
+
+test.describe('Invite Signup - Per Role', () => {
+  test('admin invite → signup → auto-accept → admin dashboard', async ({ page }) => {
+    const invite = testInviteTokens.adminInvite;
+
+    // Visit invite page
+    await page.goto(`/invite/${invite.token}`);
+
+    // Check for application error (missing service key)
+    const appError = page.locator('text=/Application error/i');
+    if (await appError.isVisible().catch(() => false)) {
+      test.skip(true, 'Service role key not available');
+      return;
+    }
+
+    // Should see invite details
+    const inviteHeading = page.getByRole('heading', { name: /convidado/i });
+    const hasInvite = await inviteHeading.isVisible({ timeout: 10000 }).catch(() => false);
+    if (!hasInvite) {
+      // Invite may have been consumed already
+      test.skip(true, 'Invite token not available — re-seed test data');
+      return;
+    }
+
+    // Click "Criar Conta" link to go to signup
+    const signupLink = page.getByRole('link', { name: /criar conta/i });
+    await signupLink.click();
+
+    // Fill signup form
+    await page.waitForSelector('input[name="full_name"]', { state: 'visible', timeout: 5000 });
+    await page.fill('input[name="full_name"]', 'E2E Admin User');
+    await page.fill('input[name="email"]', invite.email);
+    await page.fill('input[name="password"]', 'TestPassword123!');
+    await page.getByRole('button', { name: /criar conta/i }).first().click();
+
+    // Should be redirected to invite page for auto-accept, then to dashboard
+    await page.waitForURL(
+      url => ROLE_REDIRECTS.admin.test(url.toString()) || url.toString().includes('/invite/'),
+      { timeout: 15000 }
+    );
+
+    // If still on invite page, wait for auto-accept redirect
+    if (page.url().includes('/invite/')) {
+      await page.waitForURL(ROLE_REDIRECTS.admin, { timeout: 15000 });
+    }
+
+    expect(page.url()).not.toContain('/auth/login');
+  });
+
+  test('nutri invite → signup → auto-accept → nutri dashboard', async ({ page }) => {
+    const invite = testInviteTokens.nutriInvite;
+
+    await page.goto(`/invite/${invite.token}`);
+
+    const appError = page.locator('text=/Application error/i');
+    if (await appError.isVisible().catch(() => false)) {
+      test.skip(true, 'Service role key not available');
+      return;
+    }
+
+    const inviteHeading = page.getByRole('heading', { name: /convidado/i });
+    const hasInvite = await inviteHeading.isVisible({ timeout: 10000 }).catch(() => false);
+    if (!hasInvite) {
+      test.skip(true, 'Invite token not available — re-seed test data');
+      return;
+    }
+
+    const signupLink = page.getByRole('link', { name: /criar conta/i });
+    await signupLink.click();
+
+    await page.waitForSelector('input[name="full_name"]', { state: 'visible', timeout: 5000 });
+    await page.fill('input[name="full_name"]', 'E2E Nutri User');
+    await page.fill('input[name="email"]', invite.email);
+    await page.fill('input[name="password"]', 'TestPassword123!');
+    await page.getByRole('button', { name: /criar conta/i }).first().click();
+
+    await page.waitForURL(
+      url => ROLE_REDIRECTS.nutri.test(url.toString()) || url.toString().includes('/invite/'),
+      { timeout: 15000 }
+    );
+
+    if (page.url().includes('/invite/')) {
+      await page.waitForURL(ROLE_REDIRECTS.nutri, { timeout: 15000 });
+    }
+
+    expect(page.url()).not.toContain('/auth/login');
+  });
+
+  test('receptionist invite → signup → auto-accept → schedule', async ({ page }) => {
+    const invite = testInviteTokens.receptionistInvite;
+
+    await page.goto(`/invite/${invite.token}`);
+
+    const appError = page.locator('text=/Application error/i');
+    if (await appError.isVisible().catch(() => false)) {
+      test.skip(true, 'Service role key not available');
+      return;
+    }
+
+    const inviteHeading = page.getByRole('heading', { name: /convidado/i });
+    const hasInvite = await inviteHeading.isVisible({ timeout: 10000 }).catch(() => false);
+    if (!hasInvite) {
+      test.skip(true, 'Invite token not available — re-seed test data');
+      return;
+    }
+
+    const signupLink = page.getByRole('link', { name: /criar conta/i });
+    await signupLink.click();
+
+    await page.waitForSelector('input[name="full_name"]', { state: 'visible', timeout: 5000 });
+    await page.fill('input[name="full_name"]', 'E2E Receptionist User');
+    await page.fill('input[name="email"]', invite.email);
+    await page.fill('input[name="password"]', 'TestPassword123!');
+    await page.getByRole('button', { name: /criar conta/i }).first().click();
+
+    await page.waitForURL(
+      url => ROLE_REDIRECTS.receptionist.test(url.toString()) || url.toString().includes('/invite/'),
+      { timeout: 15000 }
+    );
+
+    if (page.url().includes('/invite/')) {
+      await page.waitForURL(ROLE_REDIRECTS.receptionist, { timeout: 15000 });
+    }
+
+    expect(page.url()).not.toContain('/auth/login');
+  });
+
+  test('patient invite → signup → auto-accept → patient dashboard', async ({ page }) => {
+    const invite = testInviteTokens.patientInvite;
+
+    await page.goto(`/invite/${invite.token}`);
+
+    const appError = page.locator('text=/Application error/i');
+    if (await appError.isVisible().catch(() => false)) {
+      test.skip(true, 'Service role key not available');
+      return;
+    }
+
+    const inviteHeading = page.getByRole('heading', { name: /convidado/i });
+    const hasInvite = await inviteHeading.isVisible({ timeout: 10000 }).catch(() => false);
+    if (!hasInvite) {
+      test.skip(true, 'Invite token not available — re-seed test data');
+      return;
+    }
+
+    const signupLink = page.getByRole('link', { name: /criar conta/i });
+    await signupLink.click();
+
+    await page.waitForSelector('input[name="full_name"]', { state: 'visible', timeout: 5000 });
+    await page.fill('input[name="full_name"]', 'E2E Patient User');
+    await page.fill('input[name="email"]', invite.email);
+    await page.fill('input[name="password"]', 'TestPassword123!');
+    await page.getByRole('button', { name: /criar conta/i }).first().click();
+
+    await page.waitForURL(
+      url => ROLE_REDIRECTS.patient.test(url.toString()) || url.toString().includes('/invite/'),
+      { timeout: 15000 }
+    );
+
+    if (page.url().includes('/invite/')) {
+      await page.waitForURL(ROLE_REDIRECTS.patient, { timeout: 15000 });
+    }
+
+    expect(page.url()).not.toContain('/auth/login');
+  });
+
+  test('signup without invite should be rejected', async ({ page }) => {
+    // Go directly to signup mode (simulating someone manually typing the URL)
+    await page.goto('/auth/login?mode=signup');
+    await page.waitForSelector('input[name="full_name"]', { state: 'visible', timeout: 5000 });
+
+    const uniqueEmail = `no-invite-${Date.now()}@example.com`;
+    await page.fill('input[name="full_name"]', 'No Invite User');
+    await page.fill('input[name="email"]', uniqueEmail);
+    await page.fill('input[name="password"]', 'TestPassword123!');
+    await page.getByRole('button', { name: /criar conta/i }).first().click();
+
+    // Should show error about needing an invite
+    await page.waitForTimeout(3000);
+    const errorMessage = page.locator('[class*="destructive"]');
+    const hasError = await errorMessage.isVisible().catch(() => false);
+
+    // Must stay on login page
+    expect(page.url()).toContain('/auth/login');
+    if (hasError) {
+      const text = await errorMessage.textContent();
+      expect(text?.toLowerCase()).toContain('convite');
+    }
+  });
+});

--- a/tests/auth/signup.spec.ts
+++ b/tests/auth/signup.spec.ts
@@ -95,10 +95,9 @@ test.describe('Signup (Invite-Only Mode)', () => {
       expect(minLength).toBe('6');
     });
 
-    test('should submit signup form', async ({ page }) => {
-      // This test just verifies the form can be submitted
-      // Actual signup depends on Supabase being available
-      const uniqueEmail = `test-${Date.now()}@example.com`;
+    test('should reject signup when email has no pending invite', async ({ page }) => {
+      // Invite-only guard: signup without a matching invite should be rejected
+      const uniqueEmail = `test-no-invite-${Date.now()}@example.com`;
 
       await loginPage.fullNameInput.fill('New Test User');
       await loginPage.emailInput.fill(uniqueEmail);
@@ -107,12 +106,19 @@ test.describe('Signup (Invite-Only Mode)', () => {
       const submitButton = page.getByRole('button', { name: /criar conta/i }).first();
       await submitButton.click();
 
-      // Wait a bit and check result - either redirects or shows error/stays on page
+      // Should show invite-required error or stay on page
       await page.waitForTimeout(3000);
       const url = page.url();
+      const hasError = await loginPage.errorMessage.isVisible().catch(() => false);
 
-      // Either succeeded (redirect) or Supabase not available (stays on login)
-      expect(url.includes('/dashboard') || url.includes('/auth/login')).toBeTruthy();
+      // Must stay on login page (signup rejected) or show error
+      expect(hasError || url.includes('/auth/login')).toBeTruthy();
+
+      // If error is visible, verify it mentions invite
+      if (hasError) {
+        const errorText = await loginPage.errorMessage.textContent();
+        expect(errorText?.toLowerCase()).toContain('convite');
+      }
     });
 
     test('should show error or stay on page when email exists', async ({ page }) => {

--- a/tests/fixtures/auth.fixture.ts
+++ b/tests/fixtures/auth.fixture.ts
@@ -104,30 +104,17 @@ export const test = base.extend<AuthFixtures>({
       return;
     }
 
-    // Auth seems available, try proper login
+    // Auth seems available, try login (signup is invite-only, not a fallback)
     let authSuccess = false;
 
     try {
       authSuccess = await login(page, testUsers.nutritionist.email, testUsers.nutritionist.password);
     } catch {
-      // Login failed, try signup
+      // Login failed
     }
 
     if (!authSuccess) {
-      try {
-        authSuccess = await signup(
-          page,
-          testUsers.nutritionist.fullName,
-          testUsers.nutritionist.email,
-          testUsers.nutritionist.password
-        );
-      } catch {
-        // Signup failed too
-      }
-    }
-
-    if (!authSuccess) {
-      testInfo.skip(true, 'Authentication failed after login and signup attempts.');
+      testInfo.skip(true, 'Authentication failed. Ensure test users are seeded via seed-test-data.ts.');
       return;
     }
 

--- a/tests/fixtures/test-data.ts
+++ b/tests/fixtures/test-data.ts
@@ -222,4 +222,24 @@ export const testInviteTokens = {
     email: 'test-expired@example.com',
     role: 'receptionist' as const,
   },
+  adminInvite: {
+    token: 'test-admin-invite-token-e2e-admin',
+    email: 'test-admin-invite@example.com',
+    role: 'admin' as const,
+  },
+  nutriInvite: {
+    token: 'test-nutri-invite-token-e2e-nutri',
+    email: 'test-nutri-invite@example.com',
+    role: 'nutri' as const,
+  },
+  receptionistInvite: {
+    token: 'test-recep-invite-token-e2e-recep',
+    email: 'test-recep-invite@example.com',
+    role: 'receptionist' as const,
+  },
+  patientInvite: {
+    token: 'test-patient-invite-token-e2e-patient',
+    email: 'test-patient-invite@example.com',
+    role: 'patient' as const,
+  },
 };

--- a/tests/organization/invite-acceptance.spec.ts
+++ b/tests/organization/invite-acceptance.spec.ts
@@ -12,7 +12,7 @@ import { testUsers, testInviteTokens } from '../fixtures/test-data';
  * Run `npx tsx scripts/seed-test-data.ts` before each test run to reset state.
  */
 test.describe('Invite Acceptance - Full Flow', () => {
-  test('invited user should be redirected to invite page and accept successfully', async ({ page }) => {
+  test('invited user should be redirected to invite page and auto-accepted', async ({ page }) => {
     // Login as the invited user (user_type='invite')
     await page.goto('/auth/login');
     await page.waitForSelector('input[name="email"]', { state: 'visible', timeout: 5000 });
@@ -21,18 +21,13 @@ test.describe('Invite Acceptance - Full Flow', () => {
     await page.click('button[type="submit"]');
 
     // Layout detects user_type='invite' + pending invite → redirects to /invite/[token]
+    // Auto-accept kicks in → redirects to dashboard automatically
     // If invite was already consumed, user may go to dashboard or org create instead
-    await page.waitForURL(/\/(invite|dashboard|organization|patients)/, { timeout: 15000 });
+    await page.waitForURL(/\/(invite|dashboard|organization|patients|plans|schedule)/, { timeout: 15000 });
 
     if (page.url().includes('/invite/')) {
-      // Should see the accept button
-      const acceptButton = page.getByRole('button', { name: /aceitar/i });
-      await expect(acceptButton).toBeVisible({ timeout: 10000 });
-
-      // Accept the invite
-      await acceptButton.click();
-
-      // Should redirect to dashboard after acceptance
+      // Auto-accept should fire automatically (no manual click needed)
+      // Wait for redirect to dashboard
       await page.waitForURL(/\/(dashboard|patients|plans|schedule|organization)/, { timeout: 15000 });
     }
 


### PR DESCRIPTION
## Summary

- **Fix critical bug**: upsert with `ignoreDuplicates: true` silently discarded admin role when accepting invite — now role is always applied
- **Invite-only signup**: server-side guard rejects signups without a pending invite token
- **Auto-accept flow**: new `AutoAcceptInvite` component accepts invite automatically after signup (no manual click)
- **Deprecate `profiles.role`**: source of truth is now `organization_members.role`; migration makes column nullable
- **Fix RLS**: admins can now create patients (policy checked `profiles.role = 'nutri'` before)
- **Cleanup**: remove duplicate `acceptInvite()`, remove default nutri role fallback

## Files changed (15)

### Database
- `supabase/migrations/20260401000001_invite_only_refactor.sql` — nullable profiles.role, fix RLS, update trigger, backfill

### Core fixes
- `src/app/api/invite/accept/route.ts` — remove `ignoreDuplicates`, remove manual profile creation
- `src/app/auth/actions.ts` — invite-only guard + redirect to invite page after signup
- `src/app/auth/login/page.tsx` — remove hidden `user_type` field
- `src/app/invite/[token]/page.tsx` — auto-accept when email matches
- `src/app/invite/[token]/_components/auto-accept-invite.tsx` — new component

### Cleanup
- `src/lib/queries/organization.ts` — remove dead `acceptInvite()`
- `src/contexts/role-context.tsx` — remove default nutri role

### Tests & seed
- `scripts/seed-test-data.ts` — nullable roles + per-role invite tokens
- `tests/auth/invite-signup-roles.spec.ts` — new: 5 E2E tests per role
- `tests/auth/signup.spec.ts` — updated for invite-only guard
- `tests/organization/invite-acceptance.spec.ts` — updated for auto-accept
- `tests/fixtures/test-data.ts` — per-role invite tokens
- `tests/fixtures/auth.fixture.ts` — remove signup fallback

## Test plan

- [x] TypeScript: zero errors (`npx tsc --noEmit`)
- [x] ESLint: zero new errors on modified files
- [x] Unit tests: 40/40 passing (`npx vitest run`)
- [x] Playwright MCP manual tests: 7/7 passing
  - Login page has no public signup
  - Signup form appears via invite mode
  - Signup without invite is rejected server-side
  - Invite page shows correct details for valid token
  - Invite page shows error for invalid token
  - Admin login shows full sidebar with "Minha Clínica"
  - Receptionist login shows restricted sidebar
- [ ] Run `npx tsx scripts/seed-test-data.ts` before E2E tests
- [ ] Run `npm run test:e2e` with Supabase running
- [ ] Apply migration on staging before production deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)